### PR TITLE
nav query parameter

### DIFF
--- a/Collection-API.md
+++ b/Collection-API.md
@@ -41,7 +41,7 @@ The collections endpoint supports the following query parameters:
 |------|------------------------------------------|---------|
 | id   | identifier for a collection or document. |  GET    |
 | page | page of the current collections members |  GET    |
-| nav  | (Default : *children*) Navigational direction of the collection. Available : `children`, `parent`, `prev`, `next`. |
+| nav  | return a related resource instead of the collection itself.  These values are supported : `children`, `parent`, `prev`, `next`. | GET |
 
 ### URI Template
 


### PR DESCRIPTION
The current description says that `children` is the default value for the `nav` query parameter.  I think that's sloppy wording - if no `nav` query parameter is provided, the resource itself is returned, e.g. the collection, not its children, which are found in the `member` property.

I am issuing this as a pull request in case I got it wrong.