### PR TITLE
Supporting metadata and citeType in Navigation Endpoint

### DIFF
--- a/Collection-Endpoint.md
+++ b/Collection-Endpoint.md
@@ -485,14 +485,14 @@ Although, this is optional, the expansion of `@type:Resource`'s metadata is advi
     "dts:citeDepth": 2, 
     "dts:citeStructure": [
         {
-            "label": "poem",
+            "dts:citeType": "poem",
             "dts:citeStructure": [
                 {
-                    "label": "line"
+                    "dts:citeType": "line"
                 }
             ]
         }
-    ]
+    ],
     "members": [
         {
             "@id" : "urn:cts:latinLit:phi1103.phi001",

--- a/Collection-Endpoint.md
+++ b/Collection-Endpoint.md
@@ -23,7 +23,7 @@ Item properties :
 - `@type` is either `Collection` or `Resource`
 - `totalItems` is the number of children contained by the object
 - (Required on Resource) `dts:citeDepth` declare the maximum depth of a readable resource.
-- (Optional) `description` is a string that describes the object. Additional descriptions may be placed in `dts:dublincore` using `dct:description`, e.g. for internationalization.
+- (Optional) `description` is a string that describes the object. Additional descriptions may be placed in `dts:dublincore` using `dc:description`, e.g. for internationalization.
 - (Optional) `member` contains members of the collection
 - (Optional) `dts:dublincore` contains Dublin Core Terms metadata
 - (Optional) `dts:extensions` contains any supplementary information provided by other ontologies/domains

--- a/Navigation-Endpoint.md
+++ b/Navigation-Endpoint.md
@@ -19,7 +19,7 @@ Item properties :
   - A list of passages can be made of ranges : `[{"start": "a", "end": "b"}]`
   - (Optional) `dts:citeType` contains information about passage type for each member. *e.g.* `{"ref": "1.2", "dts:citeType": "Poem"}`
   - (Optional) `dts:dublincore` contains Dublin Core Terms metadata for each passage : `{"ref": "1.2", "dts:dublincore": {"dc:author": "Balzac"}}`
-  - (Optional) `dts:metadata` contains metadata from other namespaces
+  - (Optional) `dts:extensions` contains metadata from other namespaces
 
 
 ## URI 
@@ -35,7 +35,7 @@ Item properties :
 | end |  (For range) End of the range of passages (inclusive, requires `start`, not to be used with `passage`) | GET |
 | groupSize | Retrieve passages in groups of this size instead of single units | GET |
 | max | Allows for limiting the number of results and getting pagination | GET | 
-| exclude | Exclude keys in members' object such as `exclude=dts:metadata` | GET |
+| exclude | Exclude keys in members' object such as `exclude=dts:extensions` | GET |
 
 ### Response Headers
 
@@ -441,7 +441,7 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
         "dts:dublincore": {
           "dc:title": "Lettre 1"
         },
-        "dts:metadata": {
+        "dts:extensions": {
           "foo:fictionalSender": "Cécile Volanges",
           "foo:fictionalRecipient": "Sophie Carnay"
         }
@@ -451,7 +451,7 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
         "dts:dublincore": {
           "dc:title": "Lettre 2"
         },
-        "dts:metadata": {
+        "dts:extensions": {
           "foo:fictionalSender": "La Marquise de Merteuil",
           "foo:fictionalRecipient": "Vicomte de Valmont"
         }
@@ -461,7 +461,7 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
         "dts:dublincore": {
           "dc:title": "Lettre 3"
         },
-        "dts:metadata": {
+        "dts:extensions": {
           "foo:fictionalSender": "Cécile Volanges",
           "foo:fictionalRecipient": "Sophie Carnay"
         }

--- a/Navigation-Endpoint.md
+++ b/Navigation-Endpoint.md
@@ -11,12 +11,16 @@ JSON wide attributes :
 Item properties :
 - `@base` is the URI of the Document API at which we can retrieve passages
 - `@id` is the ID of the current request
-- `member` is a list of passages
-  - A list of passages can be made of single `ids` : `[{"ref": "a"}, {"ref": "b"}, {"ref": "1.1"}]`
-  - A list of passages can be made of ranges : `[{"start": "a", "end": "b"}]`
 - `dts:citeDepth` defines the maximum depth of the document, *e.g.* if the a document has up to three levels, `dts:citeDepth` should be three
 - `dts:level` defines the level of the reference given. 
 - `dts:passage` contains a URI template to the Document endpoint
+- `member` is a list of passages
+  - A list of passages can be made of single `ids` : `[{"ref": "a"}, {"ref": "b"}, {"ref": "1.1"}]`
+  - A list of passages can be made of ranges : `[{"start": "a", "end": "b"}]`
+  - (Optional) `dts:citeType` contains information about passage type for each member. *e.g.* `{"ref": "1.2", "dts:citeType": "Poem"}`
+  - (Optional) `dts:dublincore` contains Dublin Core Terms metadata for each passage : `{"ref": "1.2", "dts:dublincore": {"dc:author": "Balzac"}}`
+  - (Optional) `dts:metadata` contains metadata from other namespaces
+
 
 ## URI 
 
@@ -31,7 +35,7 @@ Item properties :
 | end |  (For range) End of the range of passages (inclusive, requires `start`, not to be used with `passage`) | GET |
 | groupSize | Retrieve passages in groups of this size instead of single units | GET |
 | max | Allows for limiting the number of results and getting pagination | GET | 
-
+| metadata | Includes metadata dts:dublincore and dts:metadata fields | GET |
 
 ### Response Headers
 
@@ -353,6 +357,41 @@ The client wants to retrieve a list of grand-children ranges of two identifiers 
 
 **Waiting for [Issue #78](https://github.com/distributed-text-services/collection-api/issues/78)**
 
-### Retrieval of titles (**Future Draft Only**)
+### Retrieval of titles and additional metadata
 
-**Waiting for [Issue #80](https://github.com/distributed-text-services/collection-api/issues/80)**
+
+Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
+
+```json
+{
+    "@context": {
+        "@vocab": "https://www.w3.org/ns/hydra/core#",
+        "dc": "http://purl.org/dc/terms/",
+        "dts": "https://w3id.org/dts/api#"
+    },
+    "@id":"/api/dts/navigation/?id=http://data.bnf.fr/ark:/12148/cb11936111v",
+    "dts:citeDepth" : 3,
+    "dts:level": 3,
+    "member": [
+      {"ref": "Av", "dts:dublincore": {
+        "dc:title": "Avertissement de l'Éditeur"
+      }},
+      {"ref": "Pr", "dts:dublincore": {
+        "dc:title": "Préface"
+      }},
+      {"ref": "1", "dts:dublincore": {
+        "dc:title": "Lettre 1",
+        "dc:author": "Cécile Volanges"
+      }},
+      {"ref": "2", "dts:dublincore": {
+        "dc:title": "Lettre 2",
+        "dc:author": "La Marquise de Merteuil"
+      }},
+      {"ref": "3", "dts:dublincore": {
+        "dc:title": "Lettre 3",
+        "dc:author": "Cécile Volanges"
+      }},
+    ],
+    "dts:passage": "/dts/api/document/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
+}
+```

--- a/Navigation-Endpoint.md
+++ b/Navigation-Endpoint.md
@@ -35,7 +35,7 @@ Item properties :
 | end |  (For range) End of the range of passages (inclusive, requires `start`, not to be used with `passage`) | GET |
 | groupSize | Retrieve passages in groups of this size instead of single units | GET |
 | max | Allows for limiting the number of results and getting pagination | GET | 
-| metadata | Includes metadata dts:dublincore and dts:metadata fields | GET |
+| exclude | Exclude keys in members' object such as `exclude=dts:metadata` | GET |
 
 ### Response Headers
 
@@ -357,8 +357,19 @@ The client wants to retrieve a list of grand-children ranges of two identifiers 
 
 **Waiting for [Issue #78](https://github.com/distributed-text-services/collection-api/issues/78)**
 
-### Retrieval of titles and additional metadata
+### Retrieval of titles and generic metadata
 
+The client wants the list of passages with their title. If the given data provider has a title, then it will be provided.
+
+#### Example of url : 
+
+- `/api/dts/navigation/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2&ref=1&level=2&groupSize=2`
+
+#### Headers
+
+| Key | Value | 
+| --- | ----- |
+| Content-Type | Content-Type: application/ld+json |
 
 Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
 
@@ -367,30 +378,56 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
     "@context": {
         "@vocab": "https://www.w3.org/ns/hydra/core#",
         "dc": "http://purl.org/dc/terms/",
-        "dts": "https://w3id.org/dts/api#"
+        "dts": "https://w3id.org/dts/api#",
+        "foo": "http://foo.bar/ontology"
     },
     "@id":"/api/dts/navigation/?id=http://data.bnf.fr/ark:/12148/cb11936111v",
     "dts:citeDepth" : 3,
     "dts:level": 3,
     "member": [
-      {"ref": "Av", "dts:dublincore": {
+      {
+        "ref": "Av", 
+        "dts:dublincore": {
         "dc:title": "Avertissement de l'Éditeur"
-      }},
-      {"ref": "Pr", "dts:dublincore": {
-        "dc:title": "Préface"
-      }},
-      {"ref": "1", "dts:dublincore": {
-        "dc:title": "Lettre 1",
-        "dc:author": "Cécile Volanges"
-      }},
-      {"ref": "2", "dts:dublincore": {
-        "dc:title": "Lettre 2",
-        "dc:author": "La Marquise de Merteuil"
-      }},
-      {"ref": "3", "dts:dublincore": {
-        "dc:title": "Lettre 3",
-        "dc:author": "Cécile Volanges"
-      }},
+        }
+      },
+      {
+        "ref": "Pr", 
+        "dts:dublincore": {
+          "dc:title": "Préface"
+        }
+      },
+      {
+        "ref": "1", 
+        "dts:dublincore": {
+          "dc:title": "Lettre 1"
+        },
+        "dts:metadata": {
+          "foo:fictionalSender": "Cécile Volanges",
+          "foo:fictionalRecipient": "Sophie Carnay"
+        }
+      },
+      {
+        "ref": "2", 
+        "dts:dublincore": {
+          "dc:title": "Lettre 2"
+        },
+        "dts:metadata": {
+          "foo:fictionalSender": "La Marquise de Merteuil",
+          "foo:fictionalRecipient": "Vicomte de Valmont"
+        }
+      },
+      {
+        "ref": "3", 
+        "dts:dublincore": {
+          "dc:title": "Lettre 3"
+        },
+        "dts:metadata": {
+          "foo:fictionalSender": "Cécile Volanges",
+          "foo:fictionalRecipient": "Sophie Carnay"
+        }
+      },
+      // And so on
     ],
     "dts:passage": "/dts/api/document/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
 }

--- a/Navigation-Endpoint.md
+++ b/Navigation-Endpoint.md
@@ -353,17 +353,13 @@ The client wants to retrieve a list of grand-children ranges of two identifiers 
 }
 ```
 
-### Retrieval of typology of references (**Future Draft Only**)
+### Retrieval of typology of references 
 
-**Waiting for [Issue #78](https://github.com/distributed-text-services/collection-api/issues/78)**
-
-### Retrieval of titles and generic metadata
-
-The client wants the list of passages with their title. If the given data provider has a title, then it will be provided.
+Some passages may have a metadata type. The `citeType` refers to the type of citable node has been evaluated as. The node expects a free text or a RDF Class. A default type can be given at the root of the response object.
 
 #### Example of url : 
 
-- `/api/dts/navigation/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2&ref=1&level=2&groupSize=2`
+- `/api/dts/navigation/?id=http://data.bnf.fr/ark:/12148/cb11936111v`
 
 #### Headers
 
@@ -382,8 +378,51 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
         "foo": "http://foo.bar/ontology"
     },
     "@id":"/api/dts/navigation/?id=http://data.bnf.fr/ark:/12148/cb11936111v",
-    "dts:citeDepth" : 3,
-    "dts:level": 3,
+    "dts:citeDepth" : 1,
+    "dts:level": 1,
+    "dts:citeType": "letter",
+    "member": [
+      // The two following items are not letters : the data provider notes this different
+      { "ref": "Av", "dts:citeType": "preface"},
+      { "ref": "Pr", "dts:citeType": "preface"},
+      // Given the fact the following nodes have no citeType, they inherit of the root object citeType : letter
+      { "ref": "1" },
+      { "ref": "2" },
+      { "ref": "3" },
+      // And so on
+    ],
+    "dts:passage": "/dts/api/document/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
+}
+```
+
+
+### Retrieval of titles and generic metadata
+
+The client wants the list of passages with their title. If the given data provider has a title, then it will be provided.
+
+#### Example of url : 
+
+- `/api/dts/navigation/?id=http://data.bnf.fr/ark:/12148/cb11936111v`
+
+#### Headers
+
+| Key | Value | 
+| --- | ----- |
+| Content-Type | Content-Type: application/ld+json |
+
+Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
+
+```json
+{
+    "@context": {
+        "@vocab": "https://www.w3.org/ns/hydra/core#",
+        "dc": "http://purl.org/dc/terms/",
+        "dts": "https://w3id.org/dts/api#",
+        "foo": "http://foo.bar/ontology"
+    },
+    "@id":"/api/dts/navigation/?id=http://data.bnf.fr/ark:/12148/cb11936111v",
+    "dts:citeDepth" : 1,
+    "dts:level": 1,
     "member": [
       {
         "ref": "Av", 


### PR DESCRIPTION
You'll find some proposed resolution to #80 (Adding titles) and #78 (Citation Type in Navigation).

I added in there a filter that would allow clients to filter out dts:metadata and dts:dublincore.