### PR TITLE
fix typo

### DIFF
--- a/Collection-Endpoint.md
+++ b/Collection-Endpoint.md
@@ -493,7 +493,7 @@ Although, this is optional, the expansion of `@type:Resource`'s metadata is advi
             ]
         }
     ],
-    "members": [
+    "member": [
         {
             "@id" : "urn:cts:latinLit:phi1103.phi001",
             "title" : "Priapeia",


### PR DESCRIPTION
I think this is just a typo -- everywhere else we are using 'member' singular and that is the hydra vocab term.