### PR TITLE
Small consistency fixes

### DIFF
--- a/Collections-Endpoint.md
+++ b/Collections-Endpoint.md
@@ -6,7 +6,7 @@ DTS does not specify URLs. Clients should discover URLs using navigation and lin
 
 ### Hydra Representation and Hierarchy
 
-DTS does not specify any particular hierarchy of collections. A collection might provide all documents in a flat collection or a collection hierarchy organized by geography, time, or any other convenient logical grouping. 
+DTS does not specify any particular hierarchy of collections. A collection might provide all documents in a flat collection or a collection hierarchy organized by geography, time, or any other convenient logical grouping.
 
 ## Scheme
 
@@ -41,12 +41,12 @@ The collections endpoint supports the following query parameters:
 | name | description                              | methods |
 |------|------------------------------------------|---------|
 | id   | identifier for a collection or document. |  GET    |
-| page | page of the current collections members |  GET    |
+| page | page of the current collection's members |  GET    |
 | nav  | whether members of the collection are its `children` (default)  or `parents` | GET |
 
 ### URI Template
 
-Here is a template of the URI for Collection API. The route itself (`/dts/api/collection/`) is up to the implementer.
+Here is a template of the URI for Collections API. The route itself (`/dts/api/collections/`) is up to the implementer.
 
 ```json
 {
@@ -56,7 +56,7 @@ Here is a template of the URI for Collection API. The route itself (`/dts/api/co
         "dts": "https://w3id.org/dts/api#"
   },
   "@type": "IriTemplate",
-  "template": "/dts/api/collection/?id={collection_id}&page={page}",
+  "template": "/dts/api/collections/?id={collection_id}&page={page}",
   "variableRepresentation": "BasicRepresentation",
   "mapping": [
     {

--- a/Collections-Endpoint.md
+++ b/Collections-Endpoint.md
@@ -28,7 +28,7 @@ Item properties :
 - (Optional) `dts:dublincore` contains Dublin Core Terms metadata
 - (Optional) `dts:extensions` contains any supplementary information provided by other ontologies/domains
 - (Optional) `dts:references` contains links to the Navigation API route for the object (TODO: mandatory in children of `member`?)
-- (Optional) `dts:passage` contains a link to the Passage API for the object
+- (Optional) `dts:passage` contains a link to the Documents API for the object
 - (Optional) `dts:download` contains a link or a list of links to a downloadable format of the object (TODO: decide on link or map of type:URL)
 - (Optional) `dts:citeStructure` holds a declared citation tree, see [Sub-collection readable](#sub-collection-readable)
 

--- a/Documents-Endpoint.md
+++ b/Documents-Endpoint.md
@@ -1,11 +1,11 @@
-# Document Endpoint
+# Documents Endpoint
 
-The documents endpoint is used to access the data for documents, as opposed to metadata (which is found in collections).  The representation of a document is up to the implementation.
+The Documents endpoint is used to access the data for documents, as opposed to metadata (which is found in collections).  The representation of a document is up to the implementation.
 
 ## Default Scheme
 
-- Implementations of the DTS document endpoint **can** support as many response formats as the content provider wishes.
-- Implementations of the DTS document endpoint  **must**, at minimum, support an `application/tei+xml` response.
+- Implementations of the DTS Documents endpoint **can** support as many response formats as the content provider wishes.
+- Implementations of the DTS Documents endpoint  **must**, at minimum, support an `application/tei+xml` response.
 - The scheme for the `application/tei+xml` needs to be containing the `<TEI>` rootnode of the namespace `http://www.tei-c.org/ns/1.0`.
 - If the document or passage returned is a reconstruction, the reconstruction of the required fragment should be embedded in the `<fragment>` element of the DTS Namespace (`https://w3id.org/dts/api#`) such as
 
@@ -24,7 +24,7 @@ The documents endpoint is used to access the data for documents, as opposed to m
 
 ### Query Parameters
 
-The documents endpoint supports the following query parameters:
+The Documents endpoint supports the following query parameters:
 
 | name | description                              | methods |
 |------|------------------------------------------|---------|
@@ -48,17 +48,17 @@ When applicable, the following links must be provided in the Link property of th
 
 | Name of the property | Description of its value |
 | -------------------- | ------------------------ |
-| prev | Previous passage of the document in the Document endpoint |
-| next | Next passage of the document in the Document endpoint |
-| up | Parent passage of the document in the Document endpoint |
-| first | First passage of the document in the Document endpoint  |
-| last | Last passage of the document in the Document endpoint |
+| prev | Previous passage of the document in the Documents endpoint |
+| next | Next passage of the document in the Documents endpoint |
+| up | Parent passage of the document in the Documents endpoint |
+| first | First passage of the document in the Documents endpoint  |
+| last | Last passage of the document in the Documents endpoint |
 | contents | Link to the Navigation Endpoint for the current document |
-| collection | Link to the Collection endpoint for the current document |
+| collections | Link to the Collections endpoint for the current document |
 
 ### URI Template
 
-Here is a template of the URI for Document API. The route itself (`/dts/api/document/`) is up to the implementer.
+Here is a template of the URI for Documents API. The route itself (`/dts/api/documents/`) is up to the implementer.
 
 ```json
 {
@@ -68,7 +68,7 @@ Here is a template of the URI for Document API. The route itself (`/dts/api/docu
         "dts": "https://w3id.org/dts/api#"
   },
   "@type": "IriTemplate",
-  "template": "/dts/api/document/?id={collection_id}&ref={ref}&start={start}&end={end}",
+  "template": "/dts/api/documents/?id={collection_id}&ref={ref}&start={start}&end={end}",
   "variableRepresentation": "BasicRepresentation",
   "mapping": [
     {
@@ -110,7 +110,7 @@ Retrieve the passage `2` of `bgu;11;2029`
 | Key | Value | 
 | --- | ----- |
 | Content-Type | Content-Type: application/tei+xml |
-| Link | </dts/api/documents/?id=bgu;11;2029&ref=1>; rel="prev", </dts/api/documents/?id=bgu;11;2029&ref=3>; rel="next", </dts/api/documents/?id=bgu;11;2029&ref=6>; rel="last", </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collection/?id=bgu;11;2029>; rel="collection" | 
+| Link | </dts/api/documents/?id=bgu;11;2029&ref=1>; rel="prev", </dts/api/documents/?id=bgu;11;2029&ref=3>; rel="next", </dts/api/documents/?id=bgu;11;2029&ref=6>; rel="last", </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collections/?id=bgu;11;2029>; rel="collections" | 
 
 #### Response
 
@@ -154,7 +154,7 @@ Retrieve the passages 1.1.1 to the passage 1.1.2
 | Key | Value | 
 | --- | ----- |
 | Content-Type | Content-Type: application/tei+xml |
-| Link | </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=1.2.1&end=1.2.2>; rel="next", </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=5.5.5&end=5.5.6>; rel="last", </dts/api/navigation/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="contents", </dts/api/collection/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="collection" | 
+| Link | </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=1.2.1&end=1.2.2>; rel="next", </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=5.5.5&end=5.5.6>; rel="last", </dts/api/navigation/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="contents", </dts/api/collections/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="collections" | 
 
 #### Response
 
@@ -196,7 +196,7 @@ Retrieve the full document bgu;11;2029
 | Key | Value | 
 | --- | ----- |
 | Content-Type | Content-Type: application/tei+xml |
-| Link | </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collection/?id=bgu;11;2029>; rel="collection" | 
+| Link | </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collections/?id=bgu;11;2029>; rel="collections" | 
 
 #### Response
 

--- a/Documents-Endpoint.md
+++ b/Documents-Endpoint.md
@@ -110,7 +110,7 @@ Retrieve the passage `2` of `bgu;11;2029`
 | Key | Value | 
 | --- | ----- |
 | Content-Type | Content-Type: application/tei+xml |
-| Link | </dts/api/documents/?id=bgu;11;2029&ref=1>; rel="prev", </dts/api/documents/?id=bgu;11;2029&ref=3>; rel="next", </dts/api/documents/?id=bgu;11;2029&ref=6>; rel="last", </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collections/?id=bgu;11;2029>; rel="collections" | 
+| Link | </dts/api/documents/?id=bgu;11;2029&ref=1>; rel="prev", </dts/api/documents/?id=bgu;11;2029&ref=3>; rel="next", </dts/api/documents/?id=bgu;11;2029&ref=6>; rel="last", </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collections/?id=bgu;11;2029>; rel="collection" | 
 
 #### Response
 
@@ -154,7 +154,7 @@ Retrieve the passages 1.1.1 to the passage 1.1.2
 | Key | Value | 
 | --- | ----- |
 | Content-Type | Content-Type: application/tei+xml |
-| Link | </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=1.2.1&end=1.2.2>; rel="next", </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=5.5.5&end=5.5.6>; rel="last", </dts/api/navigation/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="contents", </dts/api/collections/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="collections" | 
+| Link | </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=1.2.1&end=1.2.2>; rel="next", </dts/api/documents/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1&start=5.5.5&end=5.5.6>; rel="last", </dts/api/navigation/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="contents", </dts/api/collections/?id=urn:cts:latinLit:phi1318.phi001.perseus-lat1>; rel="collection" | 
 
 #### Response
 
@@ -196,7 +196,7 @@ Retrieve the full document bgu;11;2029
 | Key | Value | 
 | --- | ----- |
 | Content-Type | Content-Type: application/tei+xml |
-| Link | </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collections/?id=bgu;11;2029>; rel="collections" | 
+| Link | </dts/api/navigation/?id=bgu;11;2029>; rel="contents", </dts/api/collections/?id=bgu;11;2029>; rel="collection" | 
 
 #### Response
 

--- a/Entry.md
+++ b/Entry.md
@@ -10,9 +10,9 @@
 
 ## Media Types
 
-The Collection and Navigation endpoints of the DTS API output `application/ld+json` adhering to Hydra conventions [http://www.hydra-cg.com](http://www.hydra-cg.com). The `@id` of any resource can be any URI, which may be a URL or a URI.
+The Collections and Navigation endpoints of the DTS API output `application/ld+json` adhering to Hydra conventions [http://www.hydra-cg.com](http://www.hydra-cg.com). The `@id` of any resource can be any URI, which may be a URL or a URI.
 
-The Document endpoint of the DTS API __must__ be able to return `application/tei+xml`.  Implementers of the API may return additional media-types for document content, including, HTML, PDF, syntax trees, or image formats.
+The Documents endpoint of the DTS API __must__ be able to return `application/tei+xml`.  Implementers of the API may return additional media-types for document content, including, HTML, PDF, syntax trees, or image formats.
 
 ## Depth of secondary properties
 
@@ -27,7 +27,7 @@ In properties such as `dts:extensions` and `dts:dublincore`, the following rule 
 
 ## HTTP Status Codes
 
-Standard conventions for HTTP Status Codes are used.  No custom status codes are allowed.  The Document endpoint may report error codes in XML. See the individual endpoint specifications for detailed information.
+Standard conventions for HTTP Status Codes are used.  No custom status codes are allowed.  The Documents endpoint may report error codes in XML. See the individual endpoint specifications for detailed information.
 
 ## Error messages
 
@@ -43,7 +43,7 @@ Parts of the APIs whose response format is LD+JSON should follow the [Hydra stan
 }
 ```
 
-The **same** situation in the document API will be encoded in XML : 
+The **same** situation in the Documents API will be encoded in XML : 
 
 ```xml
 <error statusCode="429" xmlns="https://w3id.org/dts/api#">
@@ -69,4 +69,4 @@ If the client does a `GET` on the base API endpoint,, the following response is 
 }
 ```
 
-This response provides the base path for each of the 3 specified endpoints: collection, navigation and documents. All other resources can be discovered via navigation of individual endpoint responses.  Base paths to individual endpoints URLs shown in response payloads may vary from these base endpoint paths.
+This response provides the base path for each of the 3 specified endpoints: collections, navigation and documents. All other resources can be discovered via navigation of individual endpoint responses.  Base paths to individual endpoints URLs shown in response payloads may vary from these base endpoint paths.

--- a/Navigation-Endpoint.md
+++ b/Navigation-Endpoint.md
@@ -32,8 +32,8 @@ Item properties :
 | id   | identifier for a document |  GET    |
 | ref | passage identifier (used together with `id`) | GET    |
 | level | Depth for passages we want to retrieve identifiers of  | GET    |
-| start | (For range) Start of the range passages (inclusive, not to be used with `passage`) | GET |
-| end |  (For range) End of the range of passages (inclusive, requires `start`, not to be used with `passage`) | GET |
+| start | (For range) Start of the range passages (inclusive, not to be used with `ref`) | GET |
+| end |  (For range) End of the range of passages (inclusive, requires `start`, not to be used with `ref`) | GET |
 | groupBy | Retrieve passages in groups of this size instead of single units | GET |
 | max | Allows for limiting the number of results and getting pagination | GET | 
 | exclude | Exclude keys in members' object such as `exclude=dts:extensions` | GET |
@@ -331,7 +331,7 @@ The client wants to retrieve a list of grand-children ranges of two identifiers 
 
 #### Example of url : 
 
-- `/api/dts/navigation/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2&ref=1&level=2&groupSize=2`
+- `/api/dts/navigation/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2&ref=1&level=2&groupBy=2`
 
 #### Headers
 

--- a/Navigation-Endpoint.md
+++ b/Navigation-Endpoint.md
@@ -9,12 +9,12 @@ Here is the scheme for the current draft. Everything that is not marked as Optio
 JSON wide attributes :
 
 Item properties :
-- `dts:passage` is the URI of the Document API at which we can retrieve passages
+- `dts:passage` is the URI of the Documents API at which we can retrieve passages
 - `@id` is the ID of the current request
 - `dts:citeDepth` defines the maximum depth of the document, *e.g.* if the a document has up to three levels, `dts:citeDepth` should be three
 - `dts:citeType` defines the default type of references listed in `member`
 - `dts:level` defines the level of the reference given. 
-- `dts:passage` contains a URI template to the Document endpoint
+- `dts:passage` contains a URI template to the Documents endpoint
 - `member` is a list of passages
   - A list of passages can be made of single `ids` : `[{"ref": "a"}, {"ref": "b"}, {"ref": "1.1"}]`
   - A list of passages can be made of ranges : `[{"start": "a", "end": "b"}]`
@@ -48,7 +48,7 @@ The response contains the following response headers:
 
 ### URI Template
 
-Here is a template of the URI for Collection API. The route itself (`/dts/api/navigation/`) is up to the implementer.
+Here is a template of the URI for Navigation API. The route itself (`/dts/api/navigation/`) is up to the implementer.
 
 ```json
 {
@@ -140,7 +140,7 @@ The client wants to retrieve a list of passage identifiers that are part of the 
       {"ref": "2"},
       {"ref": "3"}
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
 }
 ```
 
@@ -178,7 +178,7 @@ The client wants to retrieve a list of passage identifiers that are part of the 
       {"ref": "3.1"},
       {"ref": "3.2"}
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
 }
 ```
 
@@ -212,7 +212,7 @@ The client wants to retrieve a list of passage identifiers that are part of the 
       {"ref": "1.1"},
       {"ref": "1.2"}
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
 }
 ```
 
@@ -248,7 +248,7 @@ The client wants to retrieve a list of grand-children passage identifiers that a
       {"ref": "1.2.1"},
       {"ref": "1.2.2"}
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2{&ref}{&start}{&end}"
 }
 ```
 
@@ -283,7 +283,7 @@ The client wants to retrieve a list of passage identifiers which are between two
       {"ref": "2"},
       {"ref": "3"}
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
 }
 ```
 
@@ -321,7 +321,7 @@ The client wants to retrieve a list of passage identifiers which are between two
       {"ref": "3.1"},
       {"ref": "3.2"},
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:greekLit:tlg0012.tlg001.opp-grc{&ref}{&start}{&end}"
 }
 ```
 
@@ -356,7 +356,7 @@ The client wants to retrieve a list of grand-children ranges of two identifiers 
       {"start": "1.1.1", "end": "1.1.2"},
       {"start": "1.2.1", "end": "1.2.2"},
     ],
-    "dts:passage": "/dts/api/document/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=urn:cts:latinLit:phi1294.phi001.perseus-lat2{&ref}{&start}{&end}"
 }
 ```
 
@@ -398,7 +398,7 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
       { "ref": "3" },
       // And so on
     ],
-    "dts:passage": "/dts/api/document/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
 }
 ```
 
@@ -475,6 +475,6 @@ Example using *Les Liaisons Dangereuses* by Pierre Choderlos de Laclos
       },
       // And so on
     ],
-    "dts:passage": "/dts/api/document/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
+    "dts:passage": "/dts/api/documents/?id=http://data.bnf.fr/ark:/12148/cb11936111v{&ref}{&start}{&end}"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 The Distributed Text Services (DTS) Specification defines a Hypermedia-Driven Web API for working with collections of text as machine-actionable data.
 It specifies 3 distinct operation endpoints:
 
-- The [Collections Endpoint](Collection-Endpoint.md) is used to navigate the text collection contents
+- The [Collections Endpoint](Collections-Endpoint.md) is used to navigate the text collection contents
 - The [Navigation Endpoint](Navigation-Endpoint.md) is used to navigate within a single text document
-- The [Document Endpoint](Document-Endpoint.md) is used to retrieve complete or partial texts
+- The [Documents Endpoint](Documents-Endpoint.md) is used to retrieve complete or partial texts
 
-The Collection and Navigation endpoints are specified to return  LD+JSON adhering to the [W3C Hydra standard](http://www.hydra-cg.com/spec/latest/core/). The Document endpoint is specified to return TEI/XML of the requested text or fragment.
+The Collections and Navigation endpoints are specified to return  LD+JSON adhering to the [W3C Hydra standard](http://www.hydra-cg.com/spec/latest/core/). The Documents endpoint is specified to return TEI/XML of the requested text or fragment.
 
 Note that DTS is a *specification* for an API and not in and of itself an implementation of that API. Reference Implementations are available (see below)
 and individual text publishers are encouraged to implement this API in their own projects where appropriate.
@@ -43,7 +43,7 @@ The DTS API enables its implementors to support:
 
 The DTS API imposes the following requirements on implementors:
 
-* Implementation of the Document endpoint requires the ability to express text as TEI/XML
+* Implementation of the Documents endpoint requires the ability to express text as TEI/XML
 
 ## Who
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The Distributed Text Services (DTS) Specification defines a Hypermedia-Driven Web API for working with collections of text as machine-actionable data.
 It specifies 3 distinct operation endpoints:
 
-- The [Collection Endpoint](Collection-Endpoint.md) is used to navigate the text collection contents
+- The [Collections Endpoint](Collection-Endpoint.md) is used to navigate the text collection contents
 - The [Navigation Endpoint](Navigation-Endpoint.md) is used to navigate within a single text document
 - The [Document Endpoint](Document-Endpoint.md) is used to retrieve complete or partial texts
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,9 @@ show_downloads: false
 menu:
   - title : "Entry Point"
     url: "Entry.html"
-  - title : "Collection Endpoint"
-    url: "Collection-Endpoint.html"
+  - title : "Collections Endpoint"
+    url: "Collections-Endpoint.html"
   - title : "Navigation Endpoint"
     url: "Navigation-Endpoint.html"
-  - title : "Document Endpoint"
-    url: "Document-Endpoint.html"
+  - title : "Documents Endpoint"
+    url: "Documents-Endpoint.html"


### PR DESCRIPTION
I edited cases in which the documentation was not using "Documents" or "Collections" (plural) endpoints and fixed the Capitalization at some points. Also there were inconsistencies between 'groupBy'/'groupSize' and 'ref'/'passage' parameters I think and at very few places copy'n'paste errors (I assume) had lead to "Collection API" instead of "Navigation API" being written in the text.