### PR TITLE
JSON-LD context referencing terms of OWL ontology

### DIFF
--- a/context/1.0.0draft-proposal-ib.json
+++ b/context/1.0.0draft-proposal-ib.json
@@ -3,10 +3,6 @@
     "dts": "https://w3id.org/dts/api#",
     "dct": "http://purl.org/dc/terms/",
     "hydra": "https://www.w3.org/ns/hydra/core#",
-    "owl": "http://www.w3.org/2002/07/owl#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
 
     "CitableUnit": "dts:CitableUnit",
     "CitationTree": "dts:itationTree",

--- a/context/1.0.0draft-proposal-ib.json
+++ b/context/1.0.0draft-proposal-ib.json
@@ -53,6 +53,5 @@
     "title": "hydra:title",
     "description": "hydra:description",
     "member": "hydra:member"
-    
   }
 }

--- a/context/1.0.0draft-proposal-ib.json
+++ b/context/1.0.0draft-proposal-ib.json
@@ -1,0 +1,58 @@
+{
+  "@context": {
+    "dts": "https://w3id.org/dts/api#",
+    "dct": "http://purl.org/dc/terms/",
+    "hydra": "https://www.w3.org/ns/hydra/core#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "CitableUnit": "dts:CitableUnit",
+    "CitationTree": "dts:itationTree",
+    "CiteStructure": "dts:CiteStructure",
+    "Collection": "dts:Collection",
+    "EntryPoint": "dts:EntryPoint",
+    "MetadataObject": "dts:MetadataObject",
+    "Navigation": "dts:Navigation",
+    "Pagination": "dts:Pagination",
+    "Resource": "dts:Resource",
+
+    "citationTrees": "dts:citationTrees",
+    "citeStructure":"dts:citeStructure",
+    "dublinCore": {
+      "@id": "dts:dublinCore",
+      "@context": {
+        "@vocab": "http://purl.org/dc/terms/"
+      }
+    },
+    "end": "dts:end",
+    "extensions": "dts:extensions",
+    "first": "dts:first",
+    "last": "dts:last",
+    "next": "dts:next",
+    "previous": "dts:previous",
+    "ref": "dts:ref",
+    "resource": "dts:resource",
+    "start": "dts:start",
+    "view": "dts:view",
+    
+    "citeType": "dts:citeType",
+    "collection": "dts:collection",
+    "document": "dts:document",
+    "download": "dts:download",
+    "dtsVersion": "dts:dtsVersion",
+    "identifier": "dts:identifier",
+    "level": "dts:level",
+    "mediaTypes": "dts:mediaTypes",
+    "navigation": "dts:navigation",
+    "parent": "dts:parent",
+    "totalChildren": "dts:totalChildren",
+    "totalParents": "dts:totalParents",
+    
+    "title": "hydra:title",
+    "description": "hydra:description",
+    "member": "hydra:member"
+    
+  }
+}

--- a/context/dts-ontology.ttl
+++ b/context/dts-ontology.ttl
@@ -8,7 +8,7 @@
 @prefix schema: <http://schema.org/> . # Used by Hydra domainIncludes. If Hydra is not used, this is not needed.
 
 
-<https://w3id.org/dts/api#>
+<https://w3id.org/dts/api>
     a owl:Ontology ;
     owl:versionInfo "unstable";
     rdfs:label "Distributed Text Services (DTS) Vocabulary" ;
@@ -19,47 +19,47 @@
 dts:CitableUnit
     a owl:Class ;
     rdfs:label "Citable Unit" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:CitationTree
     a owl:Class ;
     rdfs:label "Citation Tree" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:CiteStructure
     a owl:Class ;
     rdfs:label "Cite Structure" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:Collection
     a owl:Class ;
     rdfs:label "Collection" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:EntryPoint
     a owl:Class ;
     rdfs:label "Entrypoint" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:MetadataObject 
     a owl:Class ;
     rdfs:label "Metadata Object" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:Navigation
     a owl:Class ;
     rdfs:label "Navigation" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:Pagination
     a owl:Class ;
     rdfs:label "Pagination" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:Resource
     a owl:Class ;
     rdfs:label "Resource" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 ### Object Properties ###
 
@@ -69,7 +69,7 @@ dts:dublinCore
     rdfs:range dts:MetadataObject ;
     rdfs:label "dublinCore" ;
     rdfs:comment "Metadata following the Dublin Core Terms scheme" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:extensions
     a owl:ObjectProperty ;
@@ -77,7 +77,7 @@ dts:extensions
     rdfs:range dts:MetadataObject ;
     rdfs:label "extensions" ;
     rdfs:comment "Supplementary metadata following other schemes apart from Dublin Core Terms" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:citationTrees
     a owl:ObjectProperty;
@@ -85,7 +85,7 @@ dts:citationTrees
     rdfs:range dts:CitationTree ;
     rdfs:label "citationTrees" ;
     rdfs:comment "Citation Tree, outlining the types of citation in each of the Resources citation tree" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:view
     a owl:ObjectProperty;
@@ -93,7 +93,7 @@ dts:view
     rdfs:range dts:Pagination ;
     rdfs:label "view" ; 
     rdfs:comment "Pagination object for paginated responses" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 # the Object Properties of Page are tricky, range is always a dts:Collection or dts:Pagination??
 dts:first
@@ -102,7 +102,7 @@ dts:first
     rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
     rdfs:label "first" ;
     rdfs:comment "First page of the paginated result set" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:first
     a owl:ObjectProperty;
@@ -110,7 +110,7 @@ dts:first
     rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
     rdfs:label "first" ;
     rdfs:comment "First page of the paginated result set" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:previous
     a owl:ObjectProperty;
@@ -118,7 +118,7 @@ dts:previous
     rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
     rdfs:label "previous" ;
     rdfs:comment "Previous page of the paginated result set" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:next
     a owl:ObjectProperty;
@@ -126,7 +126,7 @@ dts:next
     rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
     rdfs:label "next" ;
     rdfs:comment "Next page of the paginated result set" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:last
     a owl:ObjectProperty;
@@ -134,7 +134,7 @@ dts:last
     rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
     rdfs:label "last" ;
     rdfs:comment "Last page of the paginated result set" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:resource
     a owl:ObjectProperty;
@@ -142,7 +142,7 @@ dts:resource
     rdfs:range dts:Resource ;
     rdfs:label "resource" ;
     rdfs:comment "The Resource whose citation tree is being queried" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:ref 
     a owl:ObjectProperty ;
@@ -150,7 +150,7 @@ dts:ref
     rdfs:range dts:CitableUnit ;
     rdfs:label "ref" ;
     rdfs:comment "The CitableUnit in the citation tree which is being queried" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:start
     a owl:ObjectProperty ;
@@ -158,7 +158,7 @@ dts:start
     rdfs:range dts:CitableUnit ;
     rdfs:label "start" ;
     rdfs:comment "The CitableUnit at the beginning of the range in the citation tree which is being queried" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:end
     a owl:ObjectProperty ;
@@ -166,7 +166,7 @@ dts:end
     rdfs:range dts:CitableUnit ;
     rdfs:label "end" ;
     rdfs:comment "The CitableUnit at the end of the range in the citation tree which is being queried" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:citationTrees
     a owl:ObjectProperty ;
@@ -174,7 +174,7 @@ dts:citationTrees
     rdfs:range dts:CitationTree ;
     rdfs:label "citationTrees" ;
     rdfs:comment "Links to a CitationTree object" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:citeStructure
     a owl:ObjectProperty ;
@@ -182,7 +182,7 @@ dts:citeStructure
     rdfs:range dts:citeStructure ;
     rdfs:label "citeStructure" ;
     rdfs:comment "CiteStructure objects" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 ### Data Properties ###
 
@@ -192,7 +192,7 @@ dts:dtsVersion
     rdfs:range xsd:string ;
     rdfs:label "dtsVersion" ;
     rdfs:comment "The version of the DTS specification providing the response" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> . 
+    rdfs:isDefinedBy <https://w3id.org/dts/api> . 
 
 dts:collection
     a owl:DatatypeProperty ;
@@ -200,7 +200,7 @@ dts:collection
     rdfs:range rdfs:Literal ; # it's a string, could also be xsd:anyURI, or dataType "URI Template" 
     rdfs:label "collection" ;
     rdfs:comment "Link to the Collection API endpoint" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 # Should check Class hydra:TemplatedLink to see how URI Templates are included in Hydra in the RDF
 
@@ -210,7 +210,7 @@ dts:navigation
     rdfs:range rdfs:Literal ; # it's a string, could also be xsd:anyURI, or dataType "URI Template" 
     rdfs:label "navigation" ;
     rdfs:comment "Link to the Navigation API endpoint" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:document
     a owl:DatatypeProperty ;
@@ -218,7 +218,7 @@ dts:document
     rdfs:range rdfs:Literal ;
     rdfs:label "document" ;
     rdfs:comment "Link to the Document API endpoint" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:totalParents
     a owl:DatatypeProperty ;
@@ -226,7 +226,7 @@ dts:totalParents
     rdfs:range xsd:integer ;	
     rdfs:label "totalParents" ;
     rdfs:comment "Total number of parent Collections or Resources" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .	
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .	
 
 dts:totalChildren	
     a owl:DatatypeProperty ;
@@ -234,7 +234,7 @@ dts:totalChildren
     rdfs:range xsd:integer ;	
     rdfs:label "totalChildren" ;
     rdfs:comment "Total number of child Collections or Resources" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:download
     a owl:DatatypeProperty ;
@@ -242,7 +242,7 @@ dts:download
     # rdfs:range ? URI or array
     rdfs:label "download" ;
     rdfs:comment "A link or a key: value list of media type: link to downloadable versions" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:mediaTypes
     a owl:DatatypeProperty ;
@@ -250,7 +250,7 @@ dts:mediaTypes
     rdfs:range xsd:string ; # in the Specification it is "array"
     rdfs:label "mediaTypes" ;
     rdfs:comment "string identifiers for the response body media types (Content-Type values) supported for the Resource in Document endpoint queries" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:identifier
     a owl:DatatypeProperty ;
@@ -258,7 +258,7 @@ dts:identifier
     rdfs:range xsd:string ;
     rdfs:label "identifier" ;
     rdfs:comment "String identifier of the Citation Tree or Citable Unit" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:citeType
     a owl:DatatypeProperty ;
@@ -266,15 +266,15 @@ dts:citeType
     rdfs:range xsd:string ;
     rdfs:label "citeType" ;
     rdfs:comment "Type of textual unit that appears at a given level in the citation tree. (E.g., “chapter”, “verse”)" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:level
     a owl:DatatypeProperty ;
     rdfs:domain dts:CitableUnit ;
-    rdfs:range xsd:integer
+    rdfs:range xsd:integer ;
     rdfs:label "level" ;
     rdfs:comment "Number identifying the depth at which the CitableUnit is found within the citation tree of the Resource" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:parent
     a owl:DatatypeProperty ;
@@ -282,7 +282,7 @@ dts:parent
     rdfs:range dts:NullableString ; # Should be nullable string, need to define that datatype, see below
     rdfs:label "parent" ;
     rdfs:comment "String identifier of the hierarchical parent of the CitableUnit in the Resource" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 # Custom Datatypes
 
@@ -299,7 +299,7 @@ dts:NullableString
             [ a owl:DataRange ; owl:oneOf ( "" ) ]
         )
     ] ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 ### Imported from Hydra
 

--- a/context/dts-ontology.ttl
+++ b/context/dts-ontology.ttl
@@ -1,0 +1,337 @@
+@prefix dts: <https://w3id.org/dts/api#> .
+@prefix hydra: <https://www.w3.org/ns/hydra/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <http://schema.org/> . # Used by Hydra domainIncludes. If Hydra is not used, this is not needed.
+
+
+<https://w3id.org/dts/api#>
+    a owl:Ontology ;
+    owl:versionInfo "unstable";
+    rdfs:label "Distributed Text Services (DTS) Vocabulary" ;
+    rdfs:seeAlso "https://distributed-text-services.github.io/specifications" .
+
+### Classes ###
+
+dts:CitableUnit
+    a owl:Class ;
+    rdfs:label "Citable Unit" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:CitationTree
+    a owl:Class ;
+    rdfs:label "Citation Tree" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:CiteStructure
+    a owl:Class ;
+    rdfs:label "Cite Structure" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:Collection
+    a owl:Class ;
+    rdfs:label "Collection" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:EntryPoint
+    a owl:Class ;
+    rdfs:label "Entrypoint" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:MetadataObject 
+    a owl:Class ;
+    rdfs:label "Metadata Object" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:Navigation
+    a owl:Class ;
+    rdfs:label "Navigation" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:Pagination
+    a owl:Class ;
+    rdfs:label "Pagination" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:Resource
+    a owl:Class ;
+    rdfs:label "Resource" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+### Object Properties ###
+
+dts:dublinCore
+    a owl:ObjectProperty ;
+    rdfs:domain dts:Collection, dts:Resource, dts:CitableUnit ;
+    rdfs:range dts:MetadataObject ;
+    rdfs:label "dublinCore" ;
+    rdfs:comment "Metadata following the Dublin Core Terms scheme" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:extensions
+    a owl:ObjectProperty ;
+    rdfs:domain dts:Collection, dts:Resource, dts:CitableUnit ;
+    rdfs:range dts:MetadataObject ;
+    rdfs:label "extensions" ;
+    rdfs:comment "Supplementary metadata following other schemes apart from Dublin Core Terms" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:citationTrees
+    a owl:ObjectProperty;
+    rdfs:domain dts:Resource ;
+    rdfs:range dts:CitationTree ;
+    rdfs:label "citationTrees" ;
+    rdfs:comment "Citation Tree, outlining the types of citation in each of the Resources citation tree" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:view
+    a owl:ObjectProperty;
+    rdfs:domain dts:Collection, dts:Resource ;
+    rdfs:range dts:Pagination ;
+    rdfs:label "view" ; 
+    rdfs:comment "Pagination object for paginated responses" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+# the Object Properties of Page are tricky, range is always a dts:Collection or dts:Pagination??
+dts:first
+    a owl:ObjectProperty;
+    rdfs:domain dts:Pagination ;
+    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:label "first" ;
+    rdfs:comment "First page of the paginated result set" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:first
+    a owl:ObjectProperty;
+    rdfs:domain dts:Pagination ;
+    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:label "first" ;
+    rdfs:comment "First page of the paginated result set" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:previous
+    a owl:ObjectProperty;
+    rdfs:domain dts:Pagination ;
+    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:label "previous" ;
+    rdfs:comment "Previous page of the paginated result set" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:next
+    a owl:ObjectProperty;
+    rdfs:domain dts:Pagination ;
+    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:label "next" ;
+    rdfs:comment "Next page of the paginated result set" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:last
+    a owl:ObjectProperty;
+    rdfs:domain dts:Pagination ;
+    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:label "last" ;
+    rdfs:comment "Last page of the paginated result set" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:resource
+    a owl:ObjectProperty;
+    rdfs:domain dts:Navigation ;
+    rdfs:range dts:Resource ;
+    rdfs:label "resource" ;
+    rdfs:comment "The Resource whose citation tree is being queried" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:ref 
+    a owl:ObjectProperty ;
+    rdfs:domain dts:Navigation ;
+    rdfs:range dts:CitableUnit ;
+    rdfs:label "ref" ;
+    rdfs:comment "The CitableUnit in the citation tree which is being queried" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:start
+    a owl:ObjectProperty ;
+    rdfs:domain dts:Navigation ;
+    rdfs:range dts:CitableUnit ;
+    rdfs:label "start" ;
+    rdfs:comment "The CitableUnit at the beginning of the range in the citation tree which is being queried" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:end
+    a owl:ObjectProperty ;
+    rdfs:domain dts:Navigation ;
+    rdfs:range dts:CitableUnit ;
+    rdfs:label "end" ;
+    rdfs:comment "The CitableUnit at the end of the range in the citation tree which is being queried" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:citationTrees
+    a owl:ObjectProperty ;
+    rdfs:domain dts:Resource ;
+    rdfs:range dts:CitationTree ;
+    rdfs:label "citationTrees" ;
+    rdfs:comment "Links to a CitationTree object" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:citeStructure
+    a owl:ObjectProperty ;
+    rdfs:domain dts:CiteStructure, dts:CitationTree ;
+    rdfs:range dts:citeStructure ;
+    rdfs:label "citeStructure" ;
+    rdfs:comment "CiteStructure objects" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+### Data Properties ###
+
+dts:dtsVersion 
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:EntryPoint, dts:Collection, dts:Resource, dts:Navigation ; 
+    rdfs:range xsd:string ;
+    rdfs:label "dtsVersion" ;
+    rdfs:comment "The version of the DTS specification providing the response" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> . 
+
+dts:collection
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:EntryPoint, dts:Collection, dts:Resource ;
+    rdfs:range rdfs:Literal ; # it's a string, could also be xsd:anyURI, or dataType "URI Template" 
+    rdfs:label "collection" ;
+    rdfs:comment "Link to the Collection API endpoint" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+# Should check Class hydra:TemplatedLink to see how URI Templates are included in Hydra in the RDF
+
+dts:navigation
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:EntryPoint, dts:Collection, dts:Resource ;
+    rdfs:range rdfs:Literal ; # it's a string, could also be xsd:anyURI, or dataType "URI Template" 
+    rdfs:label "navigation" ;
+    rdfs:comment "Link to the Navigation API endpoint" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:document
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:EntryPoint, dts:Resource ; # not dts:Collection!
+    rdfs:range rdfs:Literal ;
+    rdfs:label "document" ;
+    rdfs:comment "Link to the Document API endpoint" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:totalParents
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:Collection, dts:Resource ;
+    rdfs:range xsd:integer ;	
+    rdfs:label "totalParents" ;
+    rdfs:comment "Total number of parent Collections or Resources" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .	
+
+dts:totalChildren	
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:Collection ; # not dts:Resource!
+    rdfs:range xsd:integer ;	
+    rdfs:label "totalChildren" ;
+    rdfs:comment "Total number of child Collections or Resources" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:download
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:Collection, dts:Resource ; # also dts:Collection?
+    # rdfs:range ? URI or array
+    rdfs:label "download" ;
+    rdfs:comment "A link or a key: value list of media type: link to downloadable versions" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:mediaTypes
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:Resource ;
+    rdfs:range xsd:string ; # in the Specification it is "array"
+    rdfs:label "mediaTypes" ;
+    rdfs:comment "string identifiers for the response body media types (Content-Type values) supported for the Resource in Document endpoint queries" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:identifier
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:CitationTree, dts:CitableUnit ;
+    rdfs:range xsd:string ;
+    rdfs:label "identifier" ;
+    rdfs:comment "String identifier of the Citation Tree or Citable Unit" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:citeType
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:CiteStructure , dts:CitableUnit ;
+    rdfs:range xsd:string ;
+    rdfs:label "citeType" ;
+    rdfs:comment "Type of textual unit that appears at a given level in the citation tree. (E.g., “chapter”, “verse”)" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:level
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:CitableUnit ;
+    rdfs:range xsd:integer
+    rdfs:label "level" ;
+    rdfs:comment "Number identifying the depth at which the CitableUnit is found within the citation tree of the Resource" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+dts:parent
+    a owl:DatatypeProperty ;
+    rdfs:domain dts:CitableUnit ;
+    rdfs:range dts:NullableString ; # Should be nullable string, need to define that datatype, see below
+    rdfs:label "parent" ;
+    rdfs:comment "String identifier of the hierarchical parent of the CitableUnit in the Resource" ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+# Custom Datatypes
+
+dts:NullableString
+    a rdfs:Datatype ;
+    rdfs:label "nullable string" ;
+    rdfs:comment "A string that can be null or empty" ;
+    owl:equivalentClass [
+        a owl:Class ;
+        owl:unionOf (
+            [ a rdfs:Datatype ; 
+                owl:onDatatype xsd:string ; 
+                owl:withRestrictions ([ xsd:minLength 0 ]) ]
+            [ a owl:DataRange ; owl:oneOf ( "" ) ]
+        )
+    ] ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api#> .
+
+### Imported from Hydra
+
+# I would rather define them in the DTS Namespace: dts:title a subPropertyOf hydra:title and so on
+# Could import the whole of Hydra:
+# <https://w3id.org/dts/api#> owl:imports <http://www.w3.org/ns/hydra/core> .
+# It does not seem to be possible to import certain classes and properties only.
+
+# Below are the Hydra Properties (as in JSON-LD https://www.hydra-cg.com/spec/latest/core/core.jsonld, but written as Turtle)
+
+# hydra:title
+# a rdf:Property ;
+# rdfs:subPropertyOf rdfs:label ;
+# rdfs:label "title" ;
+# rdfs:comment "A title, often used along with a description" ;
+# rdfs:range xsd:string ;
+# schema:domainIncludes hydra:ApiDocumentation, hydra:Status, hydra:Class, hydra:SupportedProperty, hydra:Operation, hydra:Link, hydra:TemplatedLink ;
+# rdfs:isDefinedBy <http://www.w3.org/ns/hydra/core> .   
+
+# hydra:description 
+#   a rdf:Property ;
+#   rdfs:subPropertyOf rdfs:comment ;
+#   rdfs:label "description" ;
+#   rdfs:comment "A description." ;
+#   rdfs:range xsd:string ;
+#   schema:domainIncludes hydra:ApiDocumentation, hydra:Status, hydra:Class, hydra:SupportedProperty, hydra:Operation, hydra:Link, hydra:TemplatedLink ;
+#   rdfs:isDefinedBy <http://www.w3.org/ns/hydra/core> .  
+
+# hydra:member
+#   a hydra:Link ;
+#   rdfs:label "member" ;
+#   rdfs:comment "A member of the collection" ;
+#   rdfs:domain hydra:Collection ;
+#   rdfs:isDefinedBy <http://www.w3.org/ns/hydra/core> . 
+

--- a/context/dts-ontology.ttl
+++ b/context/dts-ontology.ttl
@@ -231,7 +231,7 @@ dts:navigation
         a owl:Class ;
         owl:unionOf (dts:EntryPoint dts:Collection dts:Resource)
     ] ;
-    rdfs:range dts:UriTemplate ; 
+    rdfs:range dts:UriTemplate ; # Custom Datatype, see below
     rdfs:label "navigation" ;
     rdfs:comment "Link to the Navigation API endpoint" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
@@ -242,7 +242,7 @@ dts:document
         a owl:Class ;
         owl:unionOf (dts:EntryPoint dts:Resource)
     ] ;
-    rdfs:range dts:UriTemplate ;
+    rdfs:range dts:UriTemplate ; # Custom Datatype, see below
     rdfs:label "document" ;
     rdfs:comment "Link to the Document API endpoint" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .

--- a/context/dts-ontology.ttl
+++ b/context/dts-ontology.ttl
@@ -65,7 +65,10 @@ dts:Resource
 
 dts:dublinCore
     a owl:ObjectProperty ;
-    rdfs:domain dts:Collection, dts:Resource, dts:CitableUnit ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Resource dts:CitableUnit)
+    ] ;
     rdfs:range dts:MetadataObject ;
     rdfs:label "dublinCore" ;
     rdfs:comment "Metadata following the Dublin Core Terms scheme" ;
@@ -73,7 +76,10 @@ dts:dublinCore
 
 dts:extensions
     a owl:ObjectProperty ;
-    rdfs:domain dts:Collection, dts:Resource, dts:CitableUnit ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Resource dts:CitableUnit)
+    ] ;
     rdfs:range dts:MetadataObject ;
     rdfs:label "extensions" ;
     rdfs:comment "Supplementary metadata following other schemes apart from Dublin Core Terms" ;
@@ -89,25 +95,22 @@ dts:citationTrees
 
 dts:view
     a owl:ObjectProperty;
-    rdfs:domain dts:Collection, dts:Resource ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Resource)
+    ] ;
     rdfs:range dts:Pagination ;
     rdfs:label "view" ; 
     rdfs:comment "Pagination object for paginated responses" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
-# the Object Properties of Page are tricky, range is always a dts:Collection or dts:Pagination??
 dts:first
     a owl:ObjectProperty;
     rdfs:domain dts:Pagination ;
-    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
-    rdfs:label "first" ;
-    rdfs:comment "First page of the paginated result set" ;
-    rdfs:isDefinedBy <https://w3id.org/dts/api> .
-
-dts:first
-    a owl:ObjectProperty;
-    rdfs:domain dts:Pagination ;
-    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Navigation)
+    ] ;
     rdfs:label "first" ;
     rdfs:comment "First page of the paginated result set" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
@@ -115,7 +118,10 @@ dts:first
 dts:previous
     a owl:ObjectProperty;
     rdfs:domain dts:Pagination ;
-    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Navigation)
+    ] ;
     rdfs:label "previous" ;
     rdfs:comment "Previous page of the paginated result set" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
@@ -123,7 +129,10 @@ dts:previous
 dts:next
     a owl:ObjectProperty;
     rdfs:domain dts:Pagination ;
-    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Navigation)
+    ] ;
     rdfs:label "next" ;
     rdfs:comment "Next page of the paginated result set" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
@@ -131,7 +140,10 @@ dts:next
 dts:last
     a owl:ObjectProperty;
     rdfs:domain dts:Pagination ;
-    rdfs:range dts:Collection, dts:Navigation ; # can this also be dts:Navigation (paged list of Citable Units?)?
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Navigation)
+    ] ;
     rdfs:label "last" ;
     rdfs:comment "Last page of the paginated result set" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
@@ -178,7 +190,10 @@ dts:citationTrees
 
 dts:citeStructure
     a owl:ObjectProperty ;
-    rdfs:domain dts:CiteStructure, dts:CitationTree ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:CiteStructure dts:CitationTree)
+    ] ;
     rdfs:range dts:citeStructure ;
     rdfs:label "citeStructure" ;
     rdfs:comment "CiteStructure objects" ;
@@ -188,7 +203,10 @@ dts:citeStructure
 
 dts:dtsVersion 
     a owl:DatatypeProperty ;
-    rdfs:domain dts:EntryPoint, dts:Collection, dts:Resource, dts:Navigation ; 
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:EntryPoint dts:Collection dts:Resource dts:Navigation)
+    ] ;
     rdfs:range xsd:string ;
     rdfs:label "dtsVersion" ;
     rdfs:comment "The version of the DTS specification providing the response" ;
@@ -196,33 +214,45 @@ dts:dtsVersion
 
 dts:collection
     a owl:DatatypeProperty ;
-    rdfs:domain dts:EntryPoint, dts:Collection, dts:Resource ;
-    rdfs:range rdfs:Literal ; # it's a string, could also be xsd:anyURI, or dataType "URI Template" 
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:EntryPoint dts:Collection dts:Resource)
+    ] ;
+    rdfs:range dts:UriTemplate ; # Custom Datatype, see below
     rdfs:label "collection" ;
     rdfs:comment "Link to the Collection API endpoint" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
-# Should check Class hydra:TemplatedLink to see how URI Templates are included in Hydra in the RDF
+# Should also check Class hydra:TemplatedLink to see how URI Templates are included in Hydra in the RDF
 
 dts:navigation
     a owl:DatatypeProperty ;
-    rdfs:domain dts:EntryPoint, dts:Collection, dts:Resource ;
-    rdfs:range rdfs:Literal ; # it's a string, could also be xsd:anyURI, or dataType "URI Template" 
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:EntryPoint dts:Collection dts:Resource)
+    ] ;
+    rdfs:range dts:UriTemplate ; 
     rdfs:label "navigation" ;
     rdfs:comment "Link to the Navigation API endpoint" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:document
     a owl:DatatypeProperty ;
-    rdfs:domain dts:EntryPoint, dts:Resource ; # not dts:Collection!
-    rdfs:range rdfs:Literal ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:EntryPoint dts:Resource)
+    ] ;
+    rdfs:range dts:UriTemplate ;
     rdfs:label "document" ;
     rdfs:comment "Link to the Document API endpoint" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
 
 dts:totalParents
     a owl:DatatypeProperty ;
-    rdfs:domain dts:Collection, dts:Resource ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Resource)
+    ] ;
     rdfs:range xsd:integer ;	
     rdfs:label "totalParents" ;
     rdfs:comment "Total number of parent Collections or Resources" ;
@@ -238,8 +268,14 @@ dts:totalChildren
 
 dts:download
     a owl:DatatypeProperty ;
-    rdfs:domain dts:Collection, dts:Resource ; # also dts:Collection?
-    # rdfs:range ? URI or array
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:Collection dts:Resource)
+    ] ;
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (xsd:anyURI xsd:string) # range could be either a URI or a key:value pair of mediaType:URL (no example in Specification, therefore xsd:string at the moment)
+    ] ; 
     rdfs:label "download" ;
     rdfs:comment "A link or a key: value list of media type: link to downloadable versions" ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
@@ -254,7 +290,10 @@ dts:mediaTypes
 
 dts:identifier
     a owl:DatatypeProperty ;
-    rdfs:domain dts:CitationTree, dts:CitableUnit ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:CitationTree dts:CitableUnit)
+    ] ;
     rdfs:range xsd:string ;
     rdfs:label "identifier" ;
     rdfs:comment "String identifier of the Citation Tree or Citable Unit" ;
@@ -262,7 +301,10 @@ dts:identifier
 
 dts:citeType
     a owl:DatatypeProperty ;
-    rdfs:domain dts:CiteStructure , dts:CitableUnit ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (dts:CiteStructure dts:CitableUnit)
+    ] ;
     rdfs:range xsd:string ;
     rdfs:label "citeType" ;
     rdfs:comment "Type of textual unit that appears at a given level in the citation tree. (E.g., “chapter”, “verse”)" ;
@@ -300,6 +342,23 @@ dts:NullableString
         )
     ] ;
     rdfs:isDefinedBy <https://w3id.org/dts/api> .
+
+dts:UriTemplate
+    a rdfs:Datatype ;
+    rdfs:label "uri template" ;
+    rdfs:comment "The Distributed Text Services specifications reuse the RFC 6570 for defining the syntax of URI templates used to build URL on the API in its various endpoints" ;
+    rdfs:seeAlso <https://distributed-text-services.github.io/specifications/versions/unstable/#about-uri-templates> ;
+    owl:equivalentClass [
+        a rdfs:Datatype ;
+        owl:onDatatype xsd:string ;
+        owl:withRestrictions (
+            [
+                xsd:pattern ".*\\{[^}]*\\}.*" ;  # strings containing {} placeholders, maybe must be refined
+            ]
+        )
+    ] ;
+    rdfs:isDefinedBy <https://w3id.org/dts/api> .
+ 
 
 ### Imported from Hydra
 


### PR DESCRIPTION
As mentioned in issue https://github.com/distributed-text-services/specifications/issues/271 the provided JSON-LD context of the post-alpha/pre-v1 version of DTS does not include all terms used in the JSON-LD responses.

I created an OWL Ontology (see context/dts-ontology.ttl) that defines the classes and properties used in DTS, see also https://service.tib.eu/webvowl/#iri=https://raw.githubusercontent.com/ingoboerner/dts-specifications/refs/heads/master/context/dts-ontology.ttl

I then revised the JSON-LD context (see context/1.0.0draft-proposal-ib.json) and included only the terms that are used in the current specifications. The terms reference the classes and properties included in the OWL ontology.

Regarding the three properties still coming from Hydra: They are not included in the Ontology (actually, I copied them there but uncommented them), but I included the references in the JSON-LD context.

Regarding Hydra: Is there a reason, why you still stick to directly using the Hydra properties `member`, `title` and `description`? IMHO it would also be an option to define them in the ontology as well and make the `rdfs:subPropertyOf hydra:x` An alternative would be to just define them the same way Hydra does, but then specify the specific domains and ranges that are foreseen in DTS.